### PR TITLE
Do not remove osbuild source when it doesn't exist

### DIFF
--- a/roles/composer/tasks/main.yml
+++ b/roles/composer/tasks/main.yml
@@ -59,6 +59,7 @@
 
 
 - name: "block: config osbuild source"
+  # TODO review the codition to properly remove all repo sources
   when: _rhsm_repo is defined
   block:
     - name: "Remove osbuild source (ignore errors)"

--- a/roles/composer/tasks/main.yml
+++ b/roles/composer/tasks/main.yml
@@ -59,7 +59,7 @@
 
 
 - name: "block: config osbuild source"
-  # TODO review the codition to properly remove all repo sources
+  # TODO review the condition to properly remove all repo sources
   when: _rhsm_repo is defined
   block:
     - name: "Remove osbuild source (ignore errors)"

--- a/roles/composer/tasks/main.yml
+++ b/roles/composer/tasks/main.yml
@@ -59,6 +59,7 @@
 
 
 - name: "block: config osbuild source"
+  when: _rhsm_repo is defined
   block:
     - name: "Remove osbuild source (ignore errors)"
       ansible.builtin.command:


### PR DESCRIPTION
Looks like it was working on my computer because I had leftovers.

This is a bugfix.